### PR TITLE
fix(ci): ensure appcast files pass pre-commit checks

### DIFF
--- a/.github/workflows/update-appcast.yml
+++ b/.github/workflows/update-appcast.yml
@@ -30,11 +30,11 @@ jobs:
           VERSION: ${{ github.event.client_payload.version }}
           DOWNLOAD_URL: ${{ github.event.client_payload.download_url }}
         run: |
-          cat > src/config.ts << EOF
-          // Auto-updated by GitHub Actions when new releases are published
-          export const LATEST_VERSION = "${VERSION}";
-          export const DOWNLOAD_URL = "${DOWNLOAD_URL}";
-          EOF
+          printf '%s\n' \
+            "// Auto-updated by GitHub Actions when new releases are published" \
+            "export const LATEST_VERSION = \"${VERSION}\";" \
+            "export const DOWNLOAD_URL = \"${DOWNLOAD_URL}\";" \
+            > src/config.ts
 
       - name: Commit and push changes
         id: commit

--- a/scripts/update-appcast.py
+++ b/scripts/update-appcast.py
@@ -181,7 +181,14 @@ def update_appcast(appcast_path: Path = APPCAST_PATH, /) -> None:
 
     prune_old_items(channel_elem)
 
+    # Write XML to file
     tree.write(appcast_path, encoding="utf-8", xml_declaration=True)
+
+    # Post-process: strip trailing whitespace and ensure trailing newline
+    # (required by pre-commit hooks)
+    content = appcast_path.read_text(encoding="utf-8")
+    lines = [line.rstrip() for line in content.splitlines()]
+    appcast_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Strip trailing whitespace from appcast.xml after generation
- Add trailing newline to appcast.xml
- Fix config.ts generation to avoid YAML heredoc whitespace issues

This fixes the Code Quality workflow failing after appcast updates.

## Test plan
- Verify the update-appcast workflow passes pre-commit checks