### PR TITLE
fix(ci): inline deployment in update-appcast workflow

### DIFF
--- a/.github/workflows/update-appcast.yml
+++ b/.github/workflows/update-appcast.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   update:
@@ -50,8 +52,24 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Trigger deployment
+      - name: Set up Bun
         if: steps.commit.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run deploy.yml
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        if: steps.commit.outputs.changed == 'true'
+        run: bun install
+
+      - name: Build project
+        if: steps.commit.outputs.changed == 'true'
+        run: bun run build
+
+      - name: Deploy to GitHub Pages
+        if: steps.commit.outputs.changed == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          cname: claudeisland.engels74.net


### PR DESCRIPTION
## Summary
GITHUB_TOKEN cannot trigger workflow_dispatch events, so the deployment step was failing. 

This PR changes the approach to build and deploy inline within the update-appcast workflow instead of trying to trigger a separate workflow.

## Changes
- Remove failed `gh workflow run` approach
- Add inline Bun setup, build, and deploy steps
- Add necessary permissions for pages deployment

## Test plan
- Verify update-appcast workflow completes successfully
- Verify website is deployed after appcast updates