### PR TITLE
Skip no-commit-to-branch hook in CI for automated appcast updates

### DIFF
--- a/.github/workflows/update-appcast.yml
+++ b/.github/workflows/update-appcast.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Commit and push changes
         id: commit
+        env:
+          SKIP: no-commit-to-branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Add `SKIP: no-commit-to-branch` environment variable to the commit step in update-appcast workflow
- This allows the automated CI workflow to commit directly to main for legitimate appcast updates

## Problem
The `no-commit-to-branch` pre-commit hook blocks all commits to main, including automated CI commits from the appcast update workflow.

## Test plan
- [ ] CI passes on this PR
- [ ] Merge and re-trigger appcast update with new tag